### PR TITLE
feat(web): preserve mobile view state using React Activity boundary

### DIFF
--- a/apps/web/src/app/dashboard/register/page.tsx
+++ b/apps/web/src/app/dashboard/register/page.tsx
@@ -3,7 +3,7 @@
 import { api } from "@albert-plus/server/convex/_generated/api";
 import { useConvexAuth, usePaginatedQuery, useQuery } from "convex/react";
 import { CalendarIcon, ListIcon } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { Activity, useEffect, useRef, useState } from "react";
 import { useNextTerm, useNextYear } from "@/components/AppConfigProvider";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
@@ -172,7 +172,7 @@ const RegisterPage = () => {
 
       {/* Mobile view */}
       <div className="md:hidden flex-1 min-h-0">
-        {mobileView === "selector" ? (
+        <Activity mode={mobileView === "selector" ? "visible" : "hidden"}>
           <CourseSelector
             courseOfferingsWithCourses={displayedResults}
             onHover={setHoveredCourse}
@@ -185,9 +185,10 @@ const RegisterPage = () => {
             onCourseSelect={handleCourseSelect}
             selectedClassNumbers={selectedClassNumbers}
           />
-        ) : (
+        </Activity>
+        <Activity mode={mobileView === "calendar" ? "visible" : "hidden"}>
           <div className="h-full flex flex-col space-y-2">
-            <div className="md:hidden relative flex w-full items-start gap-2 rounded-md border border-input p-4 shadow-xs outline-none has-data-[state=checked]:border-primary/50">
+            <div className="relative flex w-full items-start gap-2 rounded-md border border-input p-4 shadow-xs outline-none has-data-[state=checked]:border-primary/50">
               <AltToggle />
             </div>
             <ScheduleCalendar
@@ -197,7 +198,7 @@ const RegisterPage = () => {
               onCourseSelect={handleCourseSelect}
             />
           </div>
-        )}
+        </Activity>
       </div>
 
       {/* Desktop view */}


### PR DESCRIPTION
**📌 What's Changed**
In register page (mobile view), after toggling between `selector` and `calendar` the state will lost.
<!-- a list of things that changed. mention any related tickets -->
- Replaced conditional rendering for mobile views with new React 19 [`<Activity>` ](https://react.dev/reference/react/Activity)
- Preserves internal component state (filters, course card expansion, scroll position) when toggling between "Courses" and "Schedule" on mobile.

Before:
https://github.com/user-attachments/assets/32accf13-01dd-40cc-b8d0-a477ebd26418

After:
https://github.com/user-attachments/assets/b5cb527b-da0d-474e-bc2e-e9a5580efe94



**✅ Actions**

<!-- a todo list to keep track of the states of this PR -->
- [ ] 

**📝 Notes for Reviewer**

<!-- things that you want reviewers to focus on or any questions you have -->
This will have a conflict with #107 which I will resolve once that PR is merged.